### PR TITLE
Add showroom zone descriptions and floorplan

### DIFF
--- a/floorplan.svg
+++ b/floorplan.svg
@@ -1,0 +1,14 @@
+<svg width="600" height="400" viewBox="0 0 600 400" xmlns="http://www.w3.org/2000/svg" font-family="Inter, Arial, sans-serif" font-size="16" text-anchor="middle">
+  <rect x="0" y="0" width="200" height="200" fill="#E4DFD4" stroke="#2C2F64" />
+  <text x="100" y="100" dominant-baseline="middle">Fashion</text>
+  <rect x="200" y="0" width="200" height="200" fill="#E4DFD4" stroke="#2C2F64" />
+  <text x="300" y="100" dominant-baseline="middle">Beauty</text>
+  <rect x="400" y="0" width="200" height="200" fill="#E4DFD4" stroke="#2C2F64" />
+  <text x="500" y="100" dominant-baseline="middle">Homeware</text>
+  <rect x="0" y="200" width="200" height="200" fill="#E4DFD4" stroke="#2C2F64" />
+  <text x="100" y="300" dominant-baseline="middle">Food &amp; Drink</text>
+  <rect x="200" y="200" width="200" height="200" fill="#E4DFD4" stroke="#2C2F64" />
+  <text x="300" y="300" dominant-baseline="middle">21+ THC &amp; Rec.</text>
+  <rect x="400" y="200" width="200" height="200" fill="#E4DFD4" stroke="#2C2F64" />
+  <text x="500" y="300" dominant-baseline="middle">Medical</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
     html { scroll-behavior: smooth; }
     .container { max-width: 1100px; }
     .card { border: 1px solid rgba(0,0,0,0.08); box-shadow: 0 10px 30px rgba(0,0,0,0.06); }
-    .floorplan { max-width: 600px; margin: 1.5rem auto; }
+    .floorplan { max-width: 600px; }
   </style>
 </head>
 
@@ -122,15 +122,17 @@
         <h2 class="text-2xl sm:text-3xl font-semibold text-brand-indigo">What is Hemp'in?</h2>
         <p class="mt-4 text-brand-charcoal max-w-3xl">Hemp'in is a curated multi‑brand pop‑up in Bangkok where products with <strong>hemp inside</strong> are presented and sold. From <em>fashion</em> to <em>beauty</em>, <em>homeware</em> to <em>food & drink</em> — if hemp is part of your product, you belong here. We showcase you during the Asia International Hemp Expo and add your collection to our online marketplace.</p>
         <p class="mt-4 text-brand-charcoal max-w-3xl">The showroom features six zones: <strong>Fashion</strong>, <strong>Beauty</strong>, <strong>Homeware</strong>, <strong>Food &amp; Drink</strong>, <strong>21+ THC &amp; Recreational</strong>, and <strong>Medical</strong>.</p>
-        <div class="floorplan" data-aos="fade-up">
-          <img src="floorplan.svg" alt="Floorplan of showroom highlighting Fashion, Beauty, Homeware, Food & Drink, 21+ THC & Recreational, and Medical zones" class="w-full h-auto rounded-xl card" />
+        <div class="mt-4 lg:grid lg:grid-cols-2 lg:gap-8 lg:items-start" data-aos="fade-up">
+          <div class="floorplan mx-auto lg:mx-0">
+            <img src="floorplan.svg" alt="Floorplan of showroom highlighting Fashion, Beauty, Homeware, Food & Drink, 21+ THC & Recreational, and Medical zones" class="w-full h-auto rounded-xl card" />
+          </div>
+          <ul class="mt-6 lg:mt-0 grid sm:grid-cols-2 gap-4 text-brand-charcoal">
+            <li class="flex gap-3"><span class="mt-1 h-2.5 w-2.5 bg-brand-indigo rounded-full"></span>Showroom retail in central Bangkok</li>
+            <li class="flex gap-3"><span class="mt-1 h-2.5 w-2.5 bg-brand-indigo rounded-full"></span>Marketplace mini‑shop creation</li>
+            <li class="flex gap-3"><span class="mt-1 h-2.5 w-2.5 bg-brand-indigo rounded-full"></span>In‑store & online sales operations</li>
+            <li class="flex gap-3"><span class="mt-1 h-2.5 w-2.5 bg-brand-indigo rounded-full"></span>Press, social & stage visibility</li>
+          </ul>
         </div>
-        <ul class="mt-6 grid sm:grid-cols-2 gap-4 text-brand-charcoal">
-          <li class="flex gap-3"><span class="mt-1 h-2.5 w-2.5 bg-brand-indigo rounded-full"></span>Showroom retail in central Bangkok</li>
-          <li class="flex gap-3"><span class="mt-1 h-2.5 w-2.5 bg-brand-indigo rounded-full"></span>Marketplace mini‑shop creation</li>
-          <li class="flex gap-3"><span class="mt-1 h-2.5 w-2.5 bg-brand-indigo rounded-full"></span>In‑store & online sales operations</li>
-          <li class="flex gap-3"><span class="mt-1 h-2.5 w-2.5 bg-brand-indigo rounded-full"></span>Press, social & stage visibility</li>
-        </ul>
       </div>
       <aside class="p-6 rounded-xl card bg-white" data-aos="fade-left">
         <div class="text-sm uppercase tracking-wider text-brand-stone">Included bonus</div>

--- a/index.html
+++ b/index.html
@@ -63,6 +63,7 @@
     html { scroll-behavior: smooth; }
     .container { max-width: 1100px; }
     .card { border: 1px solid rgba(0,0,0,0.08); box-shadow: 0 10px 30px rgba(0,0,0,0.06); }
+    .floorplan { max-width: 600px; margin: 1.5rem auto; }
   </style>
 </head>
 
@@ -120,6 +121,10 @@
       <div class="lg:col-span-2" data-aos="fade-up">
         <h2 class="text-2xl sm:text-3xl font-semibold text-brand-indigo">What is Hemp'in?</h2>
         <p class="mt-4 text-brand-charcoal max-w-3xl">Hemp'in is a curated multi‑brand pop‑up in Bangkok where products with <strong>hemp inside</strong> are presented and sold. From <em>fashion</em> to <em>beauty</em>, <em>homeware</em> to <em>food & drink</em> — if hemp is part of your product, you belong here. We showcase you during the Asia International Hemp Expo and add your collection to our online marketplace.</p>
+        <p class="mt-4 text-brand-charcoal max-w-3xl">The showroom features six zones: <strong>Fashion</strong>, <strong>Beauty</strong>, <strong>Homeware</strong>, <strong>Food &amp; Drink</strong>, <strong>21+ THC &amp; Recreational</strong>, and <strong>Medical</strong>.</p>
+        <div class="floorplan" data-aos="fade-up">
+          <img src="floorplan.svg" alt="Floorplan of showroom highlighting Fashion, Beauty, Homeware, Food & Drink, 21+ THC & Recreational, and Medical zones" class="w-full h-auto rounded-xl card" />
+        </div>
         <ul class="mt-6 grid sm:grid-cols-2 gap-4 text-brand-charcoal">
           <li class="flex gap-3"><span class="mt-1 h-2.5 w-2.5 bg-brand-indigo rounded-full"></span>Showroom retail in central Bangkok</li>
           <li class="flex gap-3"><span class="mt-1 h-2.5 w-2.5 bg-brand-indigo rounded-full"></span>Marketplace mini‑shop creation</li>


### PR DESCRIPTION
## Summary
- Describe showroom zones and add floorplan illustration with alt text.
- Style new floorplan component with custom CSS.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac27832d7c832887f9cc8aafcc73be