### PR TITLE
Link footer to Global Hemp Service

### DIFF
--- a/brand-palette.html
+++ b/brand-palette.html
@@ -364,6 +364,7 @@
 
     <footer>
       <p>HEMP’IN — Showroom • Bangkok • 1st Edition. Palette sheet for internal review & designer handoff.</p>
+      <p>© <span id="year"></span> Hemp'in — an initiative of <a href="https://www.globalhempservice.com/" target="_blank" rel="noopener">Global Hemp Service</a></p>
     </footer>
   </div>
 
@@ -402,6 +403,7 @@
         showToast('CSS tokens copied');
       } catch(e){ showToast('Copy failed'); }
     });
+    document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -328,7 +328,7 @@
   <!-- Footer -->
     <footer class="border-t border-brand-stone bg-white">
       <div class="container mx-auto px-5 py-10 text-sm text-brand-stone flex flex-col sm:flex-row items-center justify-between gap-4">
-      <div>© <span id="year"></span> Hemp'in • GAIA*PRAGMOSIS / Global Hemp Service</div>
+      <div>© <span id="year"></span> Hemp'in • an initiative of <a class="underline hover:no-underline" href="https://www.globalhempservice.com/" target="_blank" rel="noopener">Global Hemp Service</a></div>
       <div class="flex items-center gap-4">
 <a class="hover:text-brand-indigo" href="#what">About</a>
 <a class="hover:text-brand-indigo" href="#pricing">Pricing</a>


### PR DESCRIPTION
## Summary
- Replace GAIA*PRAGMOSIS reference in site footer with statement linking to Global Hemp Service as the initiative behind the showroom.
- Add the same Global Hemp Service footer note to the brand palette page, including a dynamic year.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac3653fae8832881f41b3445cf6a1d