### PR TITLE
Add client-side registration with PayPal and brand profiles

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Contact – Hemp'in</title>
+  <meta name="description" content="Get in touch with the Hemp'in team." />
+  <link rel="icon" sizes="32x32" href="/hi-logo-32.png">
+  <link rel="icon" sizes="192x192" href="/hi-logo-192.png">
+  <link rel="icon" sizes="512x512" href="/hi-logo-512.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Inter', 'ui-sans-serif', 'system-ui'],
+            display: ['Playfair Display', 'serif']
+          },
+          colors: {
+            brand: {
+              hemp: '#E4DFD4',
+              stone: '#B8B6AF',
+              indigo: '#2C2F64',
+              gold: '#C9A66B',
+              teal: '#38E2B5',
+              charcoal: '#1C1C1C',
+              offwhite: '#F8F6F2'
+            }
+          }
+        }
+      }
+    }
+  </script>
+</head>
+<body class="bg-brand-offwhite text-brand-charcoal font-sans">
+  <main class="container mx-auto px-5 py-10 max-w-xl">
+    <h1 class="text-3xl font-semibold text-brand-indigo mb-6">Contact us</h1>
+    <p>If you cannot complete online registration or have special requests, please use this form and we will get back to you.</p>
+    <form name="hempin-contact" method="POST" action="/success.html" data-netlify="true" netlify-honeypot="bot-field" class="mt-8 grid gap-4">
+      <input type="hidden" name="form-name" value="hempin-contact">
+      <p class="hidden"><label>Don’t fill this out: <input name="bot-field" /></label></p>
+
+      <label class="block">
+        <span class="text-sm text-brand-indigo">Brand name *</span>
+        <input required name="brand" type="text" class="mt-1 w-full rounded-lg border-brand-stone focus:border-brand-indigo focus:ring-brand-indigo" />
+      </label>
+      <label class="block">
+        <span class="text-sm text-brand-indigo">Website / Instagram *</span>
+        <input required name="website" type="text" class="mt-1 w-full rounded-lg border-brand-stone focus:border-brand-indigo focus:ring-brand-indigo" placeholder="https:// / @handle" />
+      </label>
+      <label class="block">
+        <span class="text-sm text-brand-indigo">Contact name *</span>
+        <input required name="contact" type="text" class="mt-1 w-full rounded-lg border-brand-stone focus:border-brand-indigo focus:ring-brand-indigo" />
+      </label>
+      <label class="block">
+        <span class="text-sm text-brand-indigo">Email *</span>
+        <input required name="email" type="email" class="mt-1 w-full rounded-lg border-brand-stone focus:border-brand-indigo focus:ring-brand-indigo" />
+      </label>
+      <label class="block">
+        <span class="text-sm text-brand-indigo">Message *</span>
+        <textarea required name="message" class="mt-1 w-full rounded-lg border-brand-stone focus:border-brand-indigo focus:ring-brand-indigo"></textarea>
+      </label>
+      <button type="submit" class="mt-2 px-6 py-3 rounded-full bg-brand-indigo text-white hover:bg-brand-indigo/90">Send</button>
+    </form>
+  </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
         <a href="#pricing" class="hover:text-brand-indigo">Pricing</a>
         <a href="#cities" class="hover:text-brand-indigo">Future editions</a>
         <a href="vernissage-rsvp.html" class="hover:text-brand-indigo">Vernissage</a>
-        <a href="#register" class="px-3 py-2 rounded-full bg-brand-indigo text-white hover:bg-brand-indigo/90">Register</a>
+        <a href="register.html" class="px-3 py-2 rounded-full bg-brand-indigo text-white hover:bg-brand-indigo/90">Register</a>
       </nav>
     </div>
   </header>
@@ -98,7 +98,7 @@
         <h1 class="font-display text-4xl sm:text-5xl leading-tight text-brand-indigo">Hemp'in — a traveling pop-up for hemp brands</h1>
         <p class="mt-4 text-brand-stone max-w-xl">Next stop: <strong>Bangkok 2025</strong> during the <strong>Asia International Hemp Expo</strong> — Nov 5–7, 2025. Future editions in Paris, Shanghai, and beyond.</p>
         <div class="mt-6 flex flex-wrap gap-3">
-          <a href="#register" class="inline-flex items-center gap-2 px-5 py-3 rounded-full bg-brand-indigo text-white hover:bg-brand-indigo/90">
+          <a href="register.html" class="inline-flex items-center gap-2 px-5 py-3 rounded-full bg-brand-indigo text-white hover:bg-brand-indigo/90">
             <span>Reserve your space</span>
           </a>
           <a href="#benefits" class="inline-flex items-center gap-2 px-5 py-3 rounded-full border border-brand-stone hover:bg-brand-hemp">See benefits</a>
@@ -267,59 +267,15 @@
   <!-- Registration Form (Netlify) -->
 <section id="register" class="py-16 sm:py-24 bg-brand-hemp">
   <div class="container mx-auto px-5">
-    <div class="max-w-3xl mx-auto">
+    <div class="max-w-2xl mx-auto text-center">
       <h2 class="text-2xl sm:text-3xl font-semibold text-brand-indigo" data-aos="fade-up">Register your brand</h2>
       <p class="mt-2 text-brand-charcoal" data-aos="fade-up" data-aos-delay="50">
-        Please fill out this short form so we can review your brand and contact you with next steps.
+        Secure your spot by registering and paying online to instantly create your profile page.
       </p>
-
-      <form name="hempin-registration" method="POST" action="/success.html" data-netlify="true" netlify-honeypot="bot-field" class="mt-8 grid gap-4" data-aos="fade-up" data-aos-delay="100">
-        <input type="hidden" name="form-name" value="hempin-registration">
-        <p class="hidden"><label>Don’t fill this out: <input name="bot-field" /></label></p>
-
-        <div class="grid sm:grid-cols-2 gap-4">
-          <label class="block">
-            <span class="text-sm text-brand-indigo">Brand name *</span>
-            <input required name="brand" type="text" class="mt-1 w-full rounded-lg border-brand-stone focus:border-brand-indigo focus:ring-brand-indigo" />
-          </label>
-          <label class="block">
-            <span class="text-sm text-brand-indigo">Website / Instagram *</span>
-            <input required name="website" type="text" class="mt-1 w-full rounded-lg border-brand-stone focus:border-brand-indigo focus:ring-brand-indigo" placeholder="https:// / @handle" />
-          </label>
-        </div>
-
-        <div class="grid sm:grid-cols-2 gap-4">
-          <label class="block">
-            <span class="text-sm text-brand-indigo">Contact name *</span>
-            <input required name="contact" type="text" class="mt-1 w-full rounded-lg border-brand-stone focus:border-brand-indigo focus:ring-brand-indigo" />
-          </label>
-          <label class="block">
-            <span class="text-sm text-brand-indigo">Email *</span>
-            <input required name="email" type="email" class="mt-1 w-full rounded-lg border-brand-stone focus:border-brand-indigo focus:ring-brand-indigo" />
-          </label>
-        </div>
-
-        <label class="block">
-          <span class="text-sm text-brand-indigo">Shipping from (country) *</span>
-          <input required name="shipping_from" type="text" class="mt-1 w-full rounded-lg border-brand-stone focus:border-brand-indigo focus:ring-brand-indigo" />
-        </label>
-
-        <fieldset class="grid gap-3 mt-2">
-          <label class="inline-flex items-center gap-2">
-            <input required type="checkbox" name="hemp_inside" class="rounded border-brand-stone text-brand-indigo focus:ring-brand-indigo" />
-            <span class="text-sm text-brand-charcoal">I confirm my products contain hemp.</span>
-          </label>
-          <label class="inline-flex items-center gap-2">
-            <input required type="checkbox" name="terms" class="rounded border-brand-stone text-brand-indigo focus:ring-brand-indigo" />
-            <span class="text-sm text-brand-charcoal">I agree to be contacted about participation and logistics.</span>
-          </label>
-        </fieldset>
-
-        <div class="mt-4 flex flex-wrap items-center gap-4">
-          <button type="submit" class="px-6 py-3 rounded-full bg-brand-indigo text-white hover:bg-brand-indigo/90">Submit application</button>
-          <a class="text-sm underline hover:no-underline" href="mailto:info@globalhempservice.com">Questions? info@globalhempservice.com</a>
-        </div>
-      </form>
+      <a href="register.html" class="mt-6 inline-flex items-center gap-2 px-5 py-3 rounded-full bg-brand-indigo text-white hover:bg-brand-indigo/90" data-aos="fade-up" data-aos-delay="100">Register now</a>
+      <p class="mt-4 text-sm text-brand-charcoal" data-aos="fade-up" data-aos-delay="150">
+        Need help or have special requests? <a class="underline hover:no-underline" href="contact.html">Contact us.</a>
+      </p>
     </div>
   </div>
 </section>
@@ -332,7 +288,7 @@
       <div class="flex items-center gap-4">
 <a class="hover:text-brand-indigo" href="#what">About</a>
 <a class="hover:text-brand-indigo" href="#pricing">Pricing</a>
-<a class="hover:text-brand-indigo" href="#register">Register</a>
+<a class="hover:text-brand-indigo" href="register.html">Register</a>
 <div class="flex flex-col">
   <a class="hover:text-brand-indigo" href="brand-palette.html">Brand palette</a>
   <a class="hover:text-brand-indigo" href="typography.html">Typography</a>

--- a/profile.html
+++ b/profile.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Brand Profile – Hemp'in</title>
+  <meta name="description" content="Manage your Hemp'in brand profile and products." />
+  <link rel="icon" sizes="32x32" href="/hi-logo-32.png">
+  <link rel="icon" sizes="192x192" href="/hi-logo-192.png">
+  <link rel="icon" sizes="512x512" href="/hi-logo-512.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Inter', 'ui-sans-serif', 'system-ui'],
+            display: ['Playfair Display', 'serif']
+          },
+          colors: {
+            brand: {
+              hemp: '#E4DFD4',
+              stone: '#B8B6AF',
+              indigo: '#2C2F64',
+              gold: '#C9A66B',
+              teal: '#38E2B5',
+              charcoal: '#1C1C1C',
+              offwhite: '#F8F6F2'
+            }
+          }
+        }
+      }
+    }
+  </script>
+</head>
+<body class="bg-brand-offwhite text-brand-charcoal font-sans">
+  <main class="container mx-auto px-5 py-10 max-w-3xl">
+    <h1 id="brand-heading" class="text-3xl font-semibold text-brand-indigo mb-6"></h1>
+    <form id="brand-form" class="grid gap-4 mb-10">
+      <label class="block">
+        <span class="text-sm text-brand-indigo">Brand name</span>
+        <input name="brand" type="text" class="mt-1 w-full rounded-lg border-brand-stone focus:border-brand-indigo focus:ring-brand-indigo" />
+      </label>
+      <label class="block">
+        <span class="text-sm text-brand-indigo">Website / Instagram</span>
+        <input name="website" type="text" class="mt-1 w-full rounded-lg border-brand-stone focus:border-brand-indigo focus:ring-brand-indigo" />
+      </label>
+      <label class="block">
+        <span class="text-sm text-brand-indigo">Contact name</span>
+        <input name="contact" type="text" class="mt-1 w-full rounded-lg border-brand-stone focus:border-brand-indigo focus:ring-brand-indigo" />
+      </label>
+      <label class="block">
+        <span class="text-sm text-brand-indigo">Email</span>
+        <input name="email" type="email" class="mt-1 w-full rounded-lg border-brand-stone focus:border-brand-indigo focus:ring-brand-indigo" />
+      </label>
+      <label class="block">
+        <span class="text-sm text-brand-indigo">Shipping from (country)</span>
+        <input name="shipping_from" type="text" class="mt-1 w-full rounded-lg border-brand-stone focus:border-brand-indigo focus:ring-brand-indigo" />
+      </label>
+      <label class="block">
+        <span class="text-sm text-brand-indigo">Status</span>
+        <select name="status" class="mt-1 w-full rounded-lg border-brand-stone focus:border-brand-indigo focus:ring-brand-indigo">
+          <option value="pending shipment to Hempin Bangkok">pending shipment to Hempin Bangkok</option>
+          <option value="received in Bangkok">received in Bangkok</option>
+          <option value="displayed">displayed</option>
+        </select>
+      </label>
+      <button type="submit" class="mt-2 px-6 py-3 rounded-full bg-brand-indigo text-white hover:bg-brand-indigo/90">Save profile</button>
+    </form>
+
+    <section>
+      <h2 class="text-2xl font-semibold text-brand-indigo mb-4">Products</h2>
+      <div id="products" class="grid gap-4"></div>
+      <button id="add-product" class="mt-4 px-4 py-2 rounded-full bg-brand-indigo text-white hover:bg-brand-indigo/90">Add product</button>
+    </section>
+  </main>
+
+  <template id="product-template">
+    <div class="border border-brand-stone rounded-lg p-4 grid gap-2">
+      <input name="name" placeholder="Product name" class="w-full rounded-lg border-brand-stone focus:border-brand-indigo focus:ring-brand-indigo" />
+      <textarea name="description" placeholder="Description" class="w-full rounded-lg border-brand-stone focus:border-brand-indigo focus:ring-brand-indigo"></textarea>
+      <input name="image" type="file" accept="image/*" class="w-full" />
+      <button class="remove text-sm text-red-600">Remove</button>
+    </div>
+  </template>
+
+  <script>
+    const params = new URLSearchParams(location.search);
+    const brandId = params.get('brand');
+    const brands = JSON.parse(localStorage.getItem('brands') || '{}');
+    if (!brandId || !brands[brandId]) {
+      document.body.innerHTML = '<main class="container mx-auto px-5 py-10"><p>Brand not found.</p></main>';
+    } else {
+      const brand = brands[brandId];
+      document.getElementById('brand-heading').textContent = brand.brand;
+      const form = document.getElementById('brand-form');
+      for (const key of ['brand','website','contact','email','shipping_from','status']) {
+        form.elements[key].value = brand[key] || '';
+      }
+      form.addEventListener('submit', e => {
+        e.preventDefault();
+        const data = Object.fromEntries(new FormData(form).entries());
+        brands[brandId] = { ...brands[brandId], ...data };
+        localStorage.setItem('brands', JSON.stringify(brands));
+        alert('Profile saved');
+      });
+
+      const productsDiv = document.getElementById('products');
+      const template = document.getElementById('product-template').content;
+
+      function renderProducts() {
+        productsDiv.innerHTML = '';
+        brands[brandId].products.forEach((p, index) => {
+          const clone = document.importNode(template, true);
+          clone.querySelector('input[name="name"]').value = p.name;
+          clone.querySelector('textarea[name="description"]').value = p.description;
+          if (p.image) {
+            const img = document.createElement('img');
+            img.src = p.image;
+            img.className = 'w-32 h-32 object-cover rounded';
+            clone.querySelector('input[name="image"]').before(img);
+          }
+          clone.querySelector('.remove').addEventListener('click', () => {
+            brands[brandId].products.splice(index,1);
+            localStorage.setItem('brands', JSON.stringify(brands));
+            renderProducts();
+          });
+          clone.querySelector('input[name="image"]').addEventListener('change', (e) => {
+            const file = e.target.files[0];
+            if (file) {
+              const reader = new FileReader();
+              reader.onload = ev => {
+                brands[brandId].products[index].image = ev.target.result;
+                localStorage.setItem('brands', JSON.stringify(brands));
+                renderProducts();
+              };
+              reader.readAsDataURL(file);
+            }
+          });
+          productsDiv.appendChild(clone);
+        });
+      }
+
+      renderProducts();
+
+      document.getElementById('add-product').addEventListener('click', () => {
+        const current = brands[brandId].products.length;
+        if (current >= 5) {
+          alert('Maximum of 5 products reached');
+          return;
+        }
+        brands[brandId].products.push({name:'',description:'',image:''});
+        localStorage.setItem('brands', JSON.stringify(brands));
+        renderProducts();
+      });
+    }
+  </script>
+</body>
+</html>

--- a/register.html
+++ b/register.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Register & Pay – Hemp'in</title>
+  <meta name="description" content="Register your brand, pay the fee, and create your Hemp'in profile instantly." />
+  <link rel="icon" sizes="32x32" href="/hi-logo-32.png">
+  <link rel="icon" sizes="192x192" href="/hi-logo-192.png">
+  <link rel="icon" sizes="512x512" href="/hi-logo-512.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Inter', 'ui-sans-serif', 'system-ui'],
+            display: ['Playfair Display', 'serif']
+          },
+          colors: {
+            brand: {
+              hemp: '#E4DFD4',
+              stone: '#B8B6AF',
+              indigo: '#2C2F64',
+              gold: '#C9A66B',
+              teal: '#38E2B5',
+              charcoal: '#1C1C1C',
+              offwhite: '#F8F6F2'
+            }
+          }
+        }
+      }
+    }
+  </script>
+</head>
+<body class="bg-brand-offwhite text-brand-charcoal font-sans">
+  <main class="container mx-auto px-5 py-10 max-w-xl">
+    <h1 class="text-3xl font-semibold text-brand-indigo mb-6">Register your brand</h1>
+    <form id="register-form" class="grid gap-4">
+      <label class="block">
+        <span class="text-sm text-brand-indigo">Brand name *</span>
+        <input required name="brand" type="text" class="mt-1 w-full rounded-lg border-brand-stone focus:border-brand-indigo focus:ring-brand-indigo" />
+      </label>
+      <label class="block">
+        <span class="text-sm text-brand-indigo">Website / Instagram *</span>
+        <input required name="website" type="text" class="mt-1 w-full rounded-lg border-brand-stone focus:border-brand-indigo focus:ring-brand-indigo" placeholder="https:// / @handle" />
+      </label>
+      <label class="block">
+        <span class="text-sm text-brand-indigo">Contact name *</span>
+        <input required name="contact" type="text" class="mt-1 w-full rounded-lg border-brand-stone focus:border-brand-indigo focus:ring-brand-indigo" />
+      </label>
+      <label class="block">
+        <span class="text-sm text-brand-indigo">Email *</span>
+        <input required name="email" type="email" class="mt-1 w-full rounded-lg border-brand-stone focus:border-brand-indigo focus:ring-brand-indigo" />
+      </label>
+      <label class="block">
+        <span class="text-sm text-brand-indigo">Shipping from (country) *</span>
+        <input required name="shipping_from" type="text" class="mt-1 w-full rounded-lg border-brand-stone focus:border-brand-indigo focus:ring-brand-indigo" />
+      </label>
+      <fieldset class="grid gap-3 mt-2">
+        <label class="inline-flex items-center gap-2">
+          <input required type="checkbox" name="hemp_inside" class="rounded border-brand-stone text-brand-indigo focus:ring-brand-indigo" />
+          <span class="text-sm text-brand-charcoal">I confirm my products contain hemp.</span>
+        </label>
+        <label class="inline-flex items-center gap-2">
+          <input required type="checkbox" name="terms" class="rounded border-brand-stone text-brand-indigo focus:ring-brand-indigo" />
+          <span class="text-sm text-brand-charcoal">I agree to the terms and logistics.</span>
+        </label>
+      </fieldset>
+      <button type="submit" class="mt-2 px-6 py-3 rounded-full bg-brand-indigo text-white hover:bg-brand-indigo/90">Continue to payment</button>
+    </form>
+    <div id="paypal-container" class="hidden mt-8">
+      <div id="paypal-button"></div>
+    </div>
+  </main>
+
+  <script src="https://www.paypal.com/sdk/js?client-id=YOUR_PAYPAL_CLIENT_ID&currency=USD"></script>
+  <script>
+    const form = document.getElementById('register-form');
+    const paypalContainer = document.getElementById('paypal-container');
+    let formData = null;
+
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      formData = Object.fromEntries(new FormData(form).entries());
+      form.classList.add('hidden');
+      paypalContainer.classList.remove('hidden');
+
+      paypal.Buttons({
+        createOrder: function(data, actions) {
+          return actions.order.create({
+            purchase_units: [{ amount: { value: '100.00' } }]
+          });
+        },
+        onApprove: function(data, actions) {
+          return actions.order.capture().then(function(details) {
+            const id = formData.brand.toLowerCase().replace(/\s+/g, '-');
+            const brands = JSON.parse(localStorage.getItem('brands') || '{}');
+            brands[id] = { ...formData, status: 'pending shipment to Hempin Bangkok', products: [] };
+            localStorage.setItem('brands', JSON.stringify(brands));
+            window.location.href = `profile.html?brand=${id}`;
+          });
+        }
+      }).render('#paypal-button');
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Introduce `register.html` to collect brand info, process PayPal payment, and generate a profile
- Add `profile.html` for brands to edit details and manage up to five products
- Replace landing page form with a call-to-action linking to the new flow and provide `contact.html` as a fallback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac38e91e78832892f4dc8f2b5c8e47